### PR TITLE
時刻のフォーマットをhh:mmからHH:mmに変更した

### DIFF
--- a/lib/TheChatTimeLineItem.jsx
+++ b/lib/TheChatTimeLineItem.jsx
@@ -135,7 +135,7 @@ class TheChatTimeLineItem extends React.Component {
               {status}
             </div>
             <div className='the-chat-time-line-item-date'>
-              {formatDate(at, 'hh:mm')}
+              {formatDate(at, TheChatTimeLineItem.TIME_FORMAT)}
             </div>
           </div>
         </div>
@@ -186,5 +186,6 @@ TheChatTimeLineItem.displayName = 'TheChatTimeLineItem'
 
 TheChatTimeLineItem.DEFAULT_WHO_IMAGE_SIZE = 42
 TheChatTimeLineItem.DEFAULT_WHO_BASE_COLOR = '#58E'
+TheChatTimeLineItem.TIME_FORMAT = 'HH:mm'
 
 export default TheChatTimeLineItem


### PR DESCRIPTION
たとえば午後4時の表記が

+ `hh:mm` だと `04:00`
+ `HH:mm` だと `16:00`

になりますが、後者が適切であろう
